### PR TITLE
[#50] Adds d3 as direct addon dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ env:
     - EMBER_TRY_SCENARIO=ember-2.18-d3-4.7
     - EMBER_TRY_SCENARIO=ember-2.18-d3-4.4.13
     - EMBER_TRY_SCENARIO=ember-2.18-d3-5.0.0
+    - EMBER_TRY_SCENARIO=ember-3.0-d3-4.1
     - EMBER_TRY_SCENARIO=ember-default
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,6 @@ This Ember Addon acts as a loader for consuming [D3.js](https://github.com/mbost
 
 ```bash
 ember install ember-d3
-
-# You might also need to add d3 directly to your project:
-yarn add d3
 ```
 
 **Requirements:**

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -62,6 +62,18 @@ module.exports = {
     },
 
     {
+      name: 'ember-3.0-d3-4.1',
+      npm: {
+        devDependencies: {
+          'ember-source': '~3.0.0'
+        },
+        dependencies: {
+          d3: '^4.1.0'
+        }
+      }
+    },
+
+    {
       name: 'ember-default',
       npm: {
         devDependencies: {}

--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
   "license": "MIT",
   "devDependencies": {
     "broccoli-asset-rev": "^2.4.5",
-    "d3": "4.1.0",
     "ember-ajax": "^3.0.0",
     "ember-cli": "^2.18.0",
     "ember-cli-app-version": "^2.0.0",
@@ -57,6 +56,7 @@
   "dependencies": {
     "broccoli-funnel": "^2.0.0",
     "broccoli-merge-trees": "^1.1.2",
+    "d3": "4.1.0",
     "d3-selection-multi": "^1.0.1",
     "ember-cli-babel": "^6.6.0"
   },


### PR DESCRIPTION
* [x] Adds d3 as direct dependency
* [x] Adds Ember v3 as test scenario in `ember try`
* [x] Adds Ember v3 as test scenario in travis

Fixes https://github.com/ivanvanderbyl/ember-d3/issues/50

According to ember-cli.com

> Addons depending on other addons. If your addon depends on another addon, install it as a dependency in your package.json:
```json
"dependencies": {
  "ember-ajax": "^0.7.1"
}
```
> An application that consumes your addon will automatically install and bundle dependencies specified this way.