### PR TITLE
Clarify that manually installing D3 is required

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ This Ember Addon acts as a loader for consuming [D3.js](https://github.com/mbost
 
 ```bash
 ember install ember-d3
+npm install d3 --save
 ```
 
 **Requirements:**


### PR DESCRIPTION
Helps people avoid #58

It isn't entirely clear to me _why_ a manual install is needed, when ember-d3 already requires a default D3 version, but given that it _is_ required, that fact should be documented.