### PR TITLE
Use unminified versions of d3 packages.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 
 const path = require('path')
+const fs = require('fs')
 const mergeTrees = require('broccoli-merge-trees')
 const Funnel = require('broccoli-funnel')
 const inclusionFilter = require('./lib/inclusion-filter')
@@ -54,7 +55,7 @@ module.exports = {
       if (isBrowserTarget === undefined) isBrowserTarget = false
       return require('resolve').sync(name, {
         basedir: target.project.root,
-        packageFilter(pkg, agr2) {
+        packageFilter(pkg, packageFileDir) {
           if (isBrowserTarget) {
             if (pkg.hasOwnProperty('unpkg')) {
               // D3 publishes browser build at `unpkg`
@@ -68,6 +69,12 @@ module.exports = {
               // Some older d3 packages (d3-request) may only contain browser directive
               pkg.main = undefined
               pkg.main = pkg.browser
+            }
+
+            // if an unminified version exists alongside the minified one, use that instead
+            let unminifiedPath = pkg.main.replace('.min.js', '.js')
+            if (pkg.main.endsWith('.min.js') && fs.existsSync(path.join(packageFileDir, unminifiedPath))) {
+              pkg.main = unminifiedPath
             }
           }
           return pkg


### PR DESCRIPTION
Debugging through minified code is hard. While debugging https://github.com/emberjs/ember-test-helpers/issues/426 I noticed that in all of the packages that I was using the entry point pointed at a `.min.js` file but there was also a non-minified version in the same folder.

This change attempts to detect that situation, and use the unminified version if it is present.

---

Feel free to close if you feel that this is not a safe assumption to make. I was only going on my limited debugging experience where this change works fine. I made these changes locally to debug, so I figured I'd shoot over a PR just in case you find this helpful.