### PR TITLE
Look more broadly for included D3 packages

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,8 +13,8 @@ module.exports = {
   name: 'ember-d3',
 
   allD3Modules(target) {
-    let deps = target.dependencies()
-    let d3ModuleNames = Object.keys(deps).filter(dep => dep.startsWith('d3'))
+    let deps = Object.values(target.project.packageInfoCache.entries).map(obj => obj.name || '')
+    let d3ModuleNames = deps.filter(dep => dep.startsWith('d3'))
     let ui = this.ui
 
     if (d3ModuleNames.indexOf('d3') === -1) {


### PR DESCRIPTION
When ember-d3 is installed in a nested addon the `d3` packages are
provided as `dependencies` of that addon. We should look at all the
loaded dependencies for any `d3` libraries.

@ivanvanderbyl and @vitch I think this fixes #48