### PR TITLE
Remove import existsSync

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,6 @@ const Funnel = require('broccoli-funnel')
 const inclusionFilter = require('./lib/inclusion-filter')
 const exclusionFilter = require('./lib/exclusion-filter')
 const UnwatchedDir = require('broccoli-source').UnwatchedDir
-const existsSync = require('exists-sync')
 
 module.exports = {
   name: 'ember-d3',


### PR DESCRIPTION
Appears to be a relic of some older code. It was causing me errors in my builds as I believe ember and various other packages no longer attempt to install it. Was going to add package to the package.json file however I don't believe it's actually being used by this package any more.